### PR TITLE
Update package.json with correct repo name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trim",
   "version": "0.0.1",
-  "repo": "nami-doc/trim.c",
+  "repo": "vendethiel/trim.c",
   "license": "MIT",
   "src": ["trim.c", "trim.h"]
 }


### PR DESCRIPTION
clib install currently fails:

```
$ clib install vendethiel/trim.c
       fetch : vendethiel/trim.c:package.json
       fetch : nami-doc/trim.c:trim.c
       error : unable to fetch nami-doc/trim.c:trim.c
```